### PR TITLE
Retrieve embeddings from ESM2 pretrained

### DIFF
--- a/esm2-testing/esm.ipynb
+++ b/esm2-testing/esm.ipynb
@@ -1,0 +1,300 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from transformers import AutoTokenizer, EsmForSequenceClassification\n",
+    "import torch"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "tokenizer_config.json: 100%|██████████| 95.0/95.0 [00:00<00:00, 758kB/s]\n",
+      "vocab.txt: 100%|██████████| 93.0/93.0 [00:00<00:00, 832kB/s]\n",
+      "special_tokens_map.json: 100%|██████████| 125/125 [00:00<00:00, 818kB/s]\n",
+      "config.json: 100%|██████████| 779/779 [00:00<00:00, 6.84MB/s]\n",
+      "model.safetensors: 100%|██████████| 595M/595M [00:15<00:00, 38.3MB/s] \n",
+      "Some weights of EsmForSequenceClassification were not initialized from the model checkpoint at facebook/esm2_t30_150M_UR50D and are newly initialized: ['classifier.dense.bias', 'classifier.dense.weight', 'classifier.out_proj.bias', 'classifier.out_proj.weight']\n",
+      "You should probably TRAIN this model on a down-stream task to be able to use it for predictions and inference.\n"
+     ]
+    }
+   ],
+   "source": [
+    "tokenizer = AutoTokenizer.from_pretrained(\"facebook/esm2_t30_150M_UR50D\")\n",
+    "model = EsmForSequenceClassification.from_pretrained(\"facebook/esm2_t30_150M_UR50D\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "inputs = tokenizer(\"MGSSHHHHHHSSGLVPRGSHMRGPNPTAASLEASAGPFTVRSFTVSRP\", return_tensors=\"pt\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'input_ids': tensor([[ 0, 20,  6,  8,  8, 21, 21, 21, 21, 21, 21,  8,  8,  6,  4,  7, 14, 10,\n",
+       "          6,  8, 21, 20, 10,  6, 14, 17, 14, 11,  5,  5,  8,  4,  9,  5,  8,  5,\n",
+       "          6, 14, 18, 11,  7, 10,  8, 18, 11,  7,  8, 10, 14,  2]]), 'attention_mask': tensor([[1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,\n",
+       "         1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,\n",
+       "         1, 1]])}"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "inputs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with torch.no_grad():\n",
+    "    logits = model(**inputs).logits"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "predicted_class_id = logits.argmax().item()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model2 = torch.load(\"esm2_t30_150M_UR50D.pt\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Using cache found in /home/nikola_dev/.cache/torch/hub/facebookresearch_esm_main\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Can be used\n",
+    "model, alphabet = torch.hub.load(\"facebookresearch/esm:main\", \"esm2_t30_150M_UR50D\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import esm"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 81,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model, alphabet = esm.pretrained.esm2_t30_150M_UR50D()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 82,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(<class 'torch.nn.modules.module.Module'>,)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "ESM2(\n",
+       "  (embed_tokens): Embedding(33, 640, padding_idx=1)\n",
+       "  (layers): ModuleList(\n",
+       "    (0-29): 30 x TransformerLayer(\n",
+       "      (self_attn): MultiheadAttention(\n",
+       "        (k_proj): Linear(in_features=640, out_features=640, bias=True)\n",
+       "        (v_proj): Linear(in_features=640, out_features=640, bias=True)\n",
+       "        (q_proj): Linear(in_features=640, out_features=640, bias=True)\n",
+       "        (out_proj): Linear(in_features=640, out_features=640, bias=True)\n",
+       "        (rot_emb): RotaryEmbedding()\n",
+       "      )\n",
+       "      (self_attn_layer_norm): LayerNorm((640,), eps=1e-05, elementwise_affine=True)\n",
+       "      (fc1): Linear(in_features=640, out_features=2560, bias=True)\n",
+       "      (fc2): Linear(in_features=2560, out_features=640, bias=True)\n",
+       "      (final_layer_norm): LayerNorm((640,), eps=1e-05, elementwise_affine=True)\n",
+       "    )\n",
+       "  )\n",
+       "  (contact_head): ContactPredictionHead(\n",
+       "    (regression): Linear(in_features=600, out_features=1, bias=True)\n",
+       "    (activation): Sigmoid()\n",
+       "  )\n",
+       "  (emb_layer_norm_after): LayerNorm((640,), eps=1e-05, elementwise_affine=True)\n",
+       "  (lm_head): RobertaLMHead(\n",
+       "    (dense): Linear(in_features=640, out_features=640, bias=True)\n",
+       "    (layer_norm): LayerNorm((640,), eps=1e-05, elementwise_affine=True)\n",
+       "  )\n",
+       ")"
+      ]
+     },
+     "execution_count": 82,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# model has a base class nn.Module\n",
+    "print(esm.model.esm2.ESM2.__bases__)\n",
+    "model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 83,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "ESM2(\n",
+       "  (embed_tokens): Embedding(33, 640, padding_idx=1)\n",
+       "  (layers): ModuleList(\n",
+       "    (0-29): 30 x TransformerLayer(\n",
+       "      (self_attn): MultiheadAttention(\n",
+       "        (k_proj): Linear(in_features=640, out_features=640, bias=True)\n",
+       "        (v_proj): Linear(in_features=640, out_features=640, bias=True)\n",
+       "        (q_proj): Linear(in_features=640, out_features=640, bias=True)\n",
+       "        (out_proj): Linear(in_features=640, out_features=640, bias=True)\n",
+       "        (rot_emb): RotaryEmbedding()\n",
+       "      )\n",
+       "      (self_attn_layer_norm): LayerNorm((640,), eps=1e-05, elementwise_affine=True)\n",
+       "      (fc1): Linear(in_features=640, out_features=2560, bias=True)\n",
+       "      (fc2): Linear(in_features=2560, out_features=640, bias=True)\n",
+       "      (final_layer_norm): LayerNorm((640,), eps=1e-05, elementwise_affine=True)\n",
+       "    )\n",
+       "  )\n",
+       "  (contact_head): Identity()\n",
+       "  (emb_layer_norm_after): Identity()\n",
+       "  (lm_head): Identity()\n",
+       ")"
+      ]
+     },
+     "execution_count": 83,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from torch.nn import Identity\n",
+    "model.contact_head = Identity()\n",
+    "model.emb_layer_norm_after = Identity()\n",
+    "model.lm_head = Identity()\n",
+    "model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 96,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model.eval()\n",
+    "batch_converter = alphabet.get_batch_converter()\n",
+    "data = [\n",
+    "    (\"protein1\", \"MKTVRQERLKSIVRILERSKEPVSGAQLAEELSVSRQVIVQDIAYLRSLGYNIVATPRGYVLAGG\"),\n",
+    "    (\"protein2\", \"MKTVRQERLKSIVRILERSKEPVSGAQLAEELSVSRQVIVQDIAYLRSLGYNIVATPRGYVLAGG\")\n",
+    "]\n",
+    "batch_labels, batch_strs, batch_tokens = batch_converter(data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 99,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with torch.no_grad():\n",
+    "    res = model(batch_tokens)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 100,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "torch.Size([2, 67, 640])"
+      ]
+     },
+     "execution_count": 100,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "res['logits'].shape"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "ssi",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Testing notebook with loading a pretrained ESM2 model, replacing contact_head with Identity layer and obtaining embeddings for input AA sequence.